### PR TITLE
add missing unit to width and height

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -215,8 +215,8 @@ export default {
           meiSurface.append(
             `<graphic xml:id="graphic_${ulid()}"
             target="${page.file.name}"
-            width="${page.width}"
-            height="${page.height}"
+            width="${page.width}px"
+            height="${page.height}px"
           />`,
           );
 


### PR DESCRIPTION
This PR adds the missing unit to the `graphic` attributes (otherwise it means MEI virtual units, which doesn't make sense).